### PR TITLE
TEEM-14936: Add support of Python 3.7

### DIFF
--- a/django_encrypted_json/utils.py
+++ b/django_encrypted_json/utils.py
@@ -3,6 +3,7 @@ import json
 import cryptography.fernet
 from django.conf import settings
 from django_pgjson.fields import get_encoder_class
+import six
 
 # Allow the use of key rotation
 if isinstance(settings.FIELD_ENCRYPTION_KEY, (tuple, list)):
@@ -82,10 +83,10 @@ def encrypt_values(data, encrypter=None, skip_keys=None):
         return {
             key: pick_encrypter(key, skip_keys, encrypt_values)(
                 value, encrypter, skip_keys)
-            for key, value in data.iteritems()
+            for key, value in six.iteritems(data)
         }
 
-    if isinstance(data, basestring):
+    if isinstance(data, six.string_types):
         return encrypter(data.encode('unicode_escape'))
 
     return encrypter(
@@ -118,10 +119,10 @@ def decrypt_values(data, decrypter=None):
     if isinstance(data, dict):
         return {
             key: decrypt_values(value, decrypter)
-            for key, value in data.iteritems()
+            for key, value in six.iteritems(data)
         }
 
-    if isinstance(data, basestring):
+    if isinstance(data, six.string_types):
         # string data! if we got a string or unicode convert it to
         # bytes first, as per http://stackoverflow.com/a/11174804.
         #

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ cryptography==1.4
 Django==1.8.4
 django-pgjson==0.3.1
 psycopg2==2.6.1
+six==1.12.0

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ Encrypted PostgreSQL json field support for Django.
 
 setup(
     name="django-encrypted-pgjson",
-    version="0.2.3",
+    version="v1.0",
     url="https://github.com/LucasRoesler/django-encrypted-json",
     license="MIT",
     platforms=["OS Independent"],
@@ -23,7 +23,8 @@ setup(
     include_package_data=False,
     install_requires=[
         'cryptography',
-        'django-pgjson'
+        'django-pgjson',
+        'six>=1.12.0',
     ],
     zip_safe=False,
     classifiers=[
@@ -36,7 +37,7 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Internet :: WWW/HTTP",
     ]
 )

--- a/tests/test_app/tests.py
+++ b/tests/test_app/tests.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from django.utils import timezone
 
 from .models import TestModel
+import six
 # Create your tests here.
 
 
@@ -83,10 +84,10 @@ class PlainJsonField(TestCase):
 
         self.assertIsInstance(raw_db_data, dict)
         self.assertNotEqual(data['test'], raw_db_data['test'])
-        self.assertIsInstance(raw_db_data['test'], basestring)
-        self.assertIsInstance(raw_db_data['datetime'], basestring)
-        self.assertIsInstance(raw_db_data['date'], basestring)
-        self.assertIsInstance(raw_db_data['with_tz'], basestring)
+        self.assertIsInstance(raw_db_data['test'], six.string_types)
+        self.assertIsInstance(raw_db_data['datetime'], six.string_types)
+        self.assertIsInstance(raw_db_data['date'], six.string_types)
+        self.assertIsInstance(raw_db_data['with_tz'], six.string_types)
         self.assertIsInstance(raw_db_data['many'], list)
         self.assertIsInstance(raw_db_data['nested_1'], dict)
         self.assertIsInstance(raw_db_data['many_nested'], list)
@@ -126,9 +127,9 @@ class PlainJsonField(TestCase):
         self.assertEquals(data['many_nested'], raw_db_data['many_nested'])
         self.assertNotEqual(data['many'], raw_db_data['many'])
         self.assertNotEqual(data['nested_1'], raw_db_data['nested_1'])
-        self.assertIsInstance(raw_db_data['datetime'], basestring)
-        self.assertIsInstance(raw_db_data['date'], basestring)
-        self.assertIsInstance(raw_db_data['with_tz'], basestring)
+        self.assertIsInstance(raw_db_data['datetime'], six.string_types)
+        self.assertIsInstance(raw_db_data['date'], six.string_types)
+        self.assertIsInstance(raw_db_data['with_tz'], six.string_types)
 
     def test_latin1(self):
         instance = TestModel.objects.create()

--- a/tests/tests_project/circle_settings.py
+++ b/tests/tests_project/circle_settings.py
@@ -1,4 +1,4 @@
-from settings import *
+from .settings import *
 
 
 DATABASES = {


### PR DESCRIPTION
# What?
- Added support of Python 3.7.

# Why?
Codebase should have the Python 2.7/3.7 compatibility.