### PR TITLE
TEEM-15849: Error while generating encrypted json on Python 3

### DIFF
--- a/django_encrypted_json/utils.py
+++ b/django_encrypted_json/utils.py
@@ -2,6 +2,7 @@ import json
 
 import cryptography.fernet
 from django.conf import settings
+from django.utils.encoding import force_bytes, force_text
 from django_pgjson.fields import get_encoder_class
 import six
 
@@ -87,11 +88,11 @@ def encrypt_values(data, encrypter=None, skip_keys=None):
         }
 
     if isinstance(data, six.string_types):
-        return encrypter(data.encode('unicode_escape'))
+        return force_text(encrypter(data.encode('unicode_escape')))
 
-    return encrypter(
-        bytes(json.dumps(data, cls=get_encoder_class()))
-    )
+    return force_text(encrypter(
+        force_bytes(json.dumps(data, cls=get_encoder_class()))
+    ))
 
 
 def decrypt_values(data, decrypter=None):


### PR DESCRIPTION
# What?
- Fixed issue for generating encrypted json. The issue is caused by a difference between string/bytes in Python versions. In python 2
cryptography lib return bytes (`str` type) which have all string methods and JSON
serializable. In python 3 it returns bytes which are failing during JSON serialization
- `force_text` allows to keep same behavior in Python 2 (str remain str) but fix it in python 3

# Why?
Simplified version in Python 3 (in Python 2 it executes well):

```
>>> import json
>>> json.dumps({'a': b'ssss'})
TypeError: Object of type bytes is not JSON serializable
```

# Jira Ticket(s)
[TEEM-15849](https://eventboard.atlassian.net/browse/TEEM-15849)