### PR TITLE
TE-37824 Upgrade Django to 4.2.20 to fix SQL injection vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cryptography==44.0.1
-Django==1.8.4
-django-pgjson==0.3.1
+Django==4.2.20
 psycopg2==2.9.9
 six==1.12.0
 setuptools==70.0.0
+-e git+https://github.com/enderlabs/django-pgjson@v1.1.6#egg=django-pgjson


### PR DESCRIPTION
What
---

- Upgraded Django from the vulnerable version 1.8.4 to Django 4.2.20 in requirements.txt.
- This update addresses a high severity security vulnerability flagged by Snyk.

 Why
---

- The previous version of Django had a known SQL Injection vulnerability via the "tolerance" parameter in GIS functions and aggregates on Oracle databases.
- Snyk reported this issue in TE-37824, recommending an upgrade to a secure version.
- Django 4.2.20 includes the security fix and is a stable LTS release, making it a suitable upgrade for long-term support and protection.

JIRA Ticket:
---
https://eptura.atlassian.net/browse/TE-37824
