### PR TITLE
TE-38808: Upgrade django-encrypted-json for compatibility with Django 5.2.10 and Python 3.10.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,57 @@
-djangp-encrypted-json
+django-encrypted-json
 =====================
 
 Some simple encrypted JSON fields for use with Django.
 
 Test status: [![Circle CI](https://circleci.com/gh/LucasRoesler/django-encrypted-json.svg?style=svg)](https://circleci.com/gh/LucasRoesler/django-encrypted-json)
 
-## Requies
+## Requirements
 
-* Django
+**Minimum Versions:**
+* Python 3.10+
+* Django 5.2+
+* PostgreSQL 14+
+
+**Dependencies:**
 * cryptography
 * django-pgjson
+* psycopg2-binary
 
-On Ubuntu you need to install `libffi-dev`
+### System Requirements
 
-    $ sudo apt-get install libffi-dev
+On Ubuntu you need to install `libffi-dev` and `libpq-dev`:
+
+    $ sudo apt-get install libffi-dev libpq-dev
+
+## Installation
+
+    $ pip install -r requirements.txt
 
 ## Testing
+
 The test requirements are found in `requirements.txt`
 
     $ pip install -r requirements.txt
 
-To run the tests
+### Run tests locally:
 
     $ cd tests
-    $ python manage.py test
+    $ python manage.py test test_app
+
+Or use the test script:
+
+    $ ./runtests.sh
+
+### Run tests with Docker:
+
+    $ docker-compose up --abort-on-container-exit
+
+## Upgrade Notes
+
+**Upgraded to Django 5.2.10 and Python 3.10** - See [UPGRADE_GUIDE.md](UPGRADE_GUIDE.md) for complete details.
+
+### Key Changes:
+- ✅ Removed Python 2 compatibility (six library)
+- ✅ Updated to Django 5.2 APIs
+- ✅ Modernized migrations to use BigAutoField
+- ✅ Added Docker support (Python 3.10 + PostgreSQL 14)

--- a/django_encrypted_json/utils.py
+++ b/django_encrypted_json/utils.py
@@ -2,9 +2,8 @@ import json
 
 import cryptography.fernet
 from django.conf import settings
-from django.utils.encoding import force_bytes, force_str as force_text
+from django.utils.encoding import force_bytes, force_str
 from django_pgjson.fields import get_encoder_class
-import six
 
 # Allow the use of key rotation
 if isinstance(settings.FIELD_ENCRYPTION_KEY, (tuple, list)):
@@ -84,13 +83,13 @@ def encrypt_values(data, encrypter=None, skip_keys=None):
         return {
             key: pick_encrypter(key, skip_keys, encrypt_values)(
                 value, encrypter, skip_keys)
-            for key, value in six.iteritems(data)
+            for key, value in data.items()
         }
 
-    if isinstance(data, six.string_types):
-        return force_text(encrypter(data.encode('unicode_escape')))
+    if isinstance(data, str):
+        return force_str(encrypter(data.encode('unicode_escape')))
 
-    return force_text(encrypter(
+    return force_str(encrypter(
         force_bytes(json.dumps(data, cls=get_encoder_class()))
     ))
 
@@ -120,10 +119,10 @@ def decrypt_values(data, decrypter=None):
     if isinstance(data, dict):
         return {
             key: decrypt_values(value, decrypter)
-            for key, value in six.iteritems(data)
+            for key, value in data.items()
         }
 
-    if isinstance(data, six.string_types):
+    if isinstance(data, str):
         # string data! if we got a string or unicode convert it to
         # bytes first, as per http://stackoverflow.com/a/11174804.
         #

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 cryptography==44.0.1
-Django==4.2.20
-psycopg2==2.9.9
-six==1.12.0
-setuptools==70.0.0
+Django==5.2.10
+psycopg2-binary==2.9.10
+setuptools==75.8.0
 -e git+https://github.com/enderlabs/django-pgjson@v1.1.6#egg=django-pgjson

--- a/setup.py
+++ b/setup.py
@@ -24,20 +24,20 @@ setup(
     install_requires=[
         'cryptography',
         'django-pgjson',
-        'six>=1.12.0',
     ],
     zip_safe=False,
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: Django",
+        "Framework :: Django :: 5.2",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Internet :: WWW/HTTP",
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ Encrypted PostgreSQL json field support for Django.
 """
 
 setup(
-    name="django-encrypted-pgjson",
+    name="django-encrypted-json",
     version="v1.1",
     url="https://github.com/enderlabs/django-encrypted-json",
     license="MIT",

--- a/tests/test_app/migrations/0001_initial.py
+++ b/tests/test_app/migrations/0001_initial.py
@@ -1,11 +1,11 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
+# Generated for Django 5.2
 from django.db import models, migrations
 import django_encrypted_json.fields
 
 
 class Migration(migrations.Migration):
+
+    initial = True
 
     dependencies = [
     ]
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='TestModel',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.BigAutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('json', django_encrypted_json.fields.EncryptedValueJsonField(default={})),
                 ('optional_json', django_encrypted_json.fields.EncryptedValueJsonField(null=True, blank=True)),
             ],

--- a/tests/test_app/migrations/0002_testmodel_partial_encrypt.py
+++ b/tests/test_app/migrations/0002_testmodel_partial_encrypt.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
+# Generated for Django 5.2
 from django.db import models, migrations
 import django_encrypted_json.fields
 

--- a/tests/test_app/migrations/0003_testmodel_partial_encrypt_w_default.py
+++ b/tests/test_app/migrations/0003_testmodel_partial_encrypt_w_default.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
+# Generated for Django 5.2
 from django.db import models, migrations
 import django_encrypted_json.fields
 

--- a/tests/test_app/tests.py
+++ b/tests/test_app/tests.py
@@ -7,7 +7,6 @@ from django.test import TestCase
 from django.utils import timezone
 
 from .models import TestModel
-import six
 # Create your tests here.
 
 
@@ -50,8 +49,8 @@ class PlainJsonField(TestCase):
     def test_default_create(self):
         instance = TestModel.objects.create()
 
-        self.assertEquals(instance.json, {})
-        self.assertEquals(instance.optional_json, None)
+        self.assertEqual(instance.json, {})
+        self.assertEqual(instance.optional_json, None)
 
     def test_saving_data(self):
         instance = TestModel.objects.create()
@@ -84,10 +83,10 @@ class PlainJsonField(TestCase):
 
         self.assertIsInstance(raw_db_data, dict)
         self.assertNotEqual(data['test'], raw_db_data['test'])
-        self.assertIsInstance(raw_db_data['test'], six.string_types)
-        self.assertIsInstance(raw_db_data['datetime'], six.string_types)
-        self.assertIsInstance(raw_db_data['date'], six.string_types)
-        self.assertIsInstance(raw_db_data['with_tz'], six.string_types)
+        self.assertIsInstance(raw_db_data['test'], str)
+        self.assertIsInstance(raw_db_data['datetime'], str)
+        self.assertIsInstance(raw_db_data['date'], str)
+        self.assertIsInstance(raw_db_data['with_tz'], str)
         self.assertIsInstance(raw_db_data['many'], list)
         self.assertIsInstance(raw_db_data['nested_1'], dict)
         self.assertIsInstance(raw_db_data['many_nested'], list)
@@ -123,13 +122,13 @@ class PlainJsonField(TestCase):
         raw_db_data = row[0]
 
         self.assertIsInstance(raw_db_data, dict)
-        self.assertEquals(data['test'], raw_db_data['test'])
-        self.assertEquals(data['many_nested'], raw_db_data['many_nested'])
+        self.assertEqual(data['test'], raw_db_data['test'])
+        self.assertEqual(data['many_nested'], raw_db_data['many_nested'])
         self.assertNotEqual(data['many'], raw_db_data['many'])
         self.assertNotEqual(data['nested_1'], raw_db_data['nested_1'])
-        self.assertIsInstance(raw_db_data['datetime'], six.string_types)
-        self.assertIsInstance(raw_db_data['date'], six.string_types)
-        self.assertIsInstance(raw_db_data['with_tz'], six.string_types)
+        self.assertIsInstance(raw_db_data['datetime'], str)
+        self.assertIsInstance(raw_db_data['date'], str)
+        self.assertIsInstance(raw_db_data['with_tz'], str)
 
     def test_latin1(self):
         instance = TestModel.objects.create()

--- a/tests/tests_project/settings.py
+++ b/tests/tests_project/settings.py
@@ -44,12 +44,12 @@ INSTALLED_APPS = (
     'test_app',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
-)
+]
 
 ROOT_URLCONF = 'tests.urls'
 
@@ -105,3 +105,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.8/howto/static-files/
 
 STATIC_URL = '/static/'
+
+# Default primary key field type
+# https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+


### PR DESCRIPTION
What?
---
Upgrade django-encrypted-json for compatibility with Django 5.2.10 and Python 3.10.16.

Why?
---
To make codebase compatible with Django 5.2.10 & Python 3.10.16 Upgarde.

Ticket:
--- 
https://eptura.atlassian.net/browse/TE-38808